### PR TITLE
Only allow .png assets to be retrieved by mod

### DIFF
--- a/CatsAndDogsMod/ModEntry.cs
+++ b/CatsAndDogsMod/ModEntry.cs
@@ -564,7 +564,7 @@ namespace CatsAndDogsMod
                 SMonitor.Log($"Cat asssets path could not be found. {catPath}", LogLevel.Warn);
                 return;
             }
-            var files = Directory.GetFiles(catPath);
+            var files = Directory.GetFiles(catPath, "*.png");
             for(var i = 0; i < files.Length; i++)
             {
                 var relFileName = AbsoluteToRelativePath(files[i], modPath);
@@ -583,7 +583,7 @@ namespace CatsAndDogsMod
                 return;
             }
 
-            var files = Directory.GetFiles(dogPath);
+            var files = Directory.GetFiles(dogPath, "*.png");
             for (var i = 0; i < files.Length; i++)
             {
                 var relFileName = AbsoluteToRelativePath(files[i], modPath);

--- a/CatsAndDogsMod/manifest.json
+++ b/CatsAndDogsMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "CatsAndDogsMod",
   "Author": "DelphinWave",
-  "Version": "2.0.2",
+  "Version": "2.0.3",
   "Description": "Allows you to adopt cats and dogs to your farm",
   "UniqueID": "DelphinWave.CatsAndDogsMod",
   "EntryDll": "CatsAndDogsMod.dll",


### PR DESCRIPTION
Fixes error caused by .DS_Store files being created within mod asset folders when on Mac.

Tested on my Mac for both cats & dogs, making sure .DS_Store exists in all folders.